### PR TITLE
use cmake-opts instead of cmake_opts in setup.py to please setuptools…

### DIFF
--- a/.github/workflows/fabm.yml
+++ b/.github/workflows/fabm.yml
@@ -234,12 +234,22 @@ jobs:
       - name: Build distribution
         run: python -m build
       - name: Install
-        run: python -m pip install .
+        run: python -m pip install -v .
       - name: Test
         run: |
           python -c "import pyfabm;print('pyfabm version =', getattr(pyfabm, '__version__', None))"
           for f in testcases/*.yaml; do fabm_describe_model $f; done
           for f in testcases/*.yaml; do fabm_complete_yaml --add_missing $f; done
+      - name: Install with customization via command line arguments
+        run: |
+          rm -rf build
+          python -m pip install -v -C--build-option=build_ext -C--build-option="--cmake-opts=-DFABM_INSTITUTES=examples" .
+      - name: Install with customization via setup.cfg
+        run: |
+          rm -rf build
+          echo "[build_ext]" > setup.cfg
+          echo "cmake_opts=-DFABM_INSTITUTES=examples" >> setup.cfg
+          python -m pip install -v .
   fabm0d:
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.repository
     runs-on: ubuntu-latest

--- a/src/drivers/python/build_cmake.py
+++ b/src/drivers/python/build_cmake.py
@@ -33,7 +33,7 @@ class CMakeExtension(Extension):
 
 class CMakeBuild(build_ext):
     user_options = build_ext.user_options + [
-        ("cmake_opts=", None, "additional options to pass to cmake"),
+        ("cmake-opts=", None, "additional options to pass to cmake"),
     ]
 
     def run(self):


### PR DESCRIPTION
… (#70)

* use cmake-opts instead of cmake_opts in setup.py to please setuptools (still cmake_opts in code and setup.cfg!)

* more pyfabm installation tests

* test pip install with command line arguments first